### PR TITLE
bugfix/27818_spaces_in_domains: Allow spaces to appear in non-web domains

### DIFF
--- a/django-os2webscanner/os2webscanner/utils.py
+++ b/django-os2webscanner/os2webscanner/utils.py
@@ -276,14 +276,9 @@ def secure_save(object):
 def domain_form_manipulate(form):
     """ Manipulates domain form fields.
     All form widgets will have added the css class 'form-control'.
-    All domain names must be without spaces.
     """
     for fname in form.fields:
         f = form.fields[fname]
         f.widget.attrs['class'] = 'form-control'
-
-    if form['url'].value():
-        if ' ' in form['url'].value():
-            form.add_error('url', u'Mellemrum er ikke tilladt i domænenavnet.')
 
     return form

--- a/django-os2webscanner/os2webscanner/views/exchangedomain_views.py
+++ b/django-os2webscanner/os2webscanner/views/exchangedomain_views.py
@@ -32,10 +32,6 @@ class ExchangeDomainCreate(DomainCreate):
         form.fields['password'] = forms.CharField(max_length=50, required=False)
         return form
 
-    def form_valid(self, form):
-        """Makes sure password gets encrypted before stored in db."""
-        return super().form_valid(form)
-
     def get_success_url(self):
         """The URL to redirect to after successful creation."""
         return '/exchangedomains/%s/created/' % self.object.pk
@@ -64,10 +60,6 @@ class ExchangeDomainUpdate(DomainUpdate):
                                bytes(authentication.ciphertext))
             form.fields['password'].initial = password
         return form
-
-    def form_valid(self, form):
-        """Makes sure password gets encrypted before stored in db."""
-        return super().form_valid(form)
 
     def get_success_url(self):
         """The URL to redirect to after successful updating.

--- a/django-os2webscanner/os2webscanner/views/filedomain_views.py
+++ b/django-os2webscanner/os2webscanner/views/filedomain_views.py
@@ -34,10 +34,6 @@ class FileDomainCreate(DomainCreate):
         form.fields['alias'] = forms.CharField(max_length=64, required=False)
         return form
 
-    def form_valid(self, form):
-        """Makes sure password gets encrypted before stored in db."""
-        return super().form_valid(form)
-
     def get_success_url(self):
         """The URL to redirect to after successful creation."""
         return '/filedomains/%s/created/' % self.object.pk
@@ -70,10 +66,6 @@ class FileDomainUpdate(DomainUpdate):
         if len(authentication.domain) > 0:
             form.fields['domain'].initial = authentication.domain
         return form
-
-    def form_valid(self, form):
-        """Makes sure password gets encrypted before stored in db."""
-        return super().form_valid(form)
 
     def get_success_url(self):
         """The URL to redirect to after successful updating.

--- a/django-os2webscanner/os2webscanner/views/webdomain_views.py
+++ b/django-os2webscanner/os2webscanner/views/webdomain_views.py
@@ -5,6 +5,10 @@ from .domain_views import DomainList, DomainCreate, DomainUpdate
 from .views import RestrictedDeleteView, RestrictedDetailView
 
 
+def url_contains_spaces(form):
+    return form['url'].value() and ' ' in form['url'].value()
+
+
 class WebDomainList(DomainList):
 
     """Displays list of domains."""
@@ -14,12 +18,17 @@ class WebDomainList(DomainList):
 
 
 class WebDomainCreate(DomainCreate):
-
     """Web domain create form."""
 
     model = WebDomain
     fields = ['url', 'exclusion_rules', 'download_sitemap', 'sitemap_url',
               'sitemap']
+
+    def form_valid(self, form):
+        if url_contains_spaces(form):
+            form.add_error('url', u'Mellemrum er ikke tilladt i web-domænenavnet.')
+            return self.form_invalid(form)
+        return super(WebDomainCreate, self).form_valid(form)
 
     def get_success_url(self):
         """The URL to redirect to after successful creation."""
@@ -32,6 +41,12 @@ class WebDomainUpdate(DomainUpdate):
     model = WebDomain
     fields = ['url', 'exclusion_rules', 'download_sitemap',
               'sitemap_url', 'sitemap']
+
+    def form_valid(self, form):
+        if url_contains_spaces(form):
+            form.add_error('url', u'Mellemrum er ikke tilladt i web-domænenavnet.')
+            return self.form_invalid(form)
+        return super(WebDomainUpdate, self).form_valid(form)
 
     def get_form_fields(self):
         fields = super().get_form_fields()


### PR DESCRIPTION
I moved the old validation code into `webdomain_views.py`, so the other kinds of domain are actually unvalidated at the moment; should we do something about that before merging this, or can that wait?