### PR TITLE
properly prevent editing most fields on scanners

### DIFF
--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/scanner_form.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/scanner_form.html
@@ -53,7 +53,7 @@ iframe-modal
       //  * Rules
       //  * Settings
       // But the user shall still be able to view them and edit interval and Recepients
-      {% if view.edit %}
+      {% if form.regex_rules.field.disabled %}
         $("#selected_rules .remove-rule").addClass('disabled')
         $("#selected_rules span").addClass('disabled')
         $("#select_scan_rules_container").css('opacity', '.35')
@@ -269,7 +269,7 @@ iframe-modal
           <div class="checkbox-group">
             <input type="checkbox" id="id_{{ form.do_ocr.name }}"
                    name="{{ form.do_ocr.name }}" value="{{ form.do_ocr.name }}"
-            {% if view.edit %}
+            {% if form.do_ocr.field.disabled %}
                 disabled
             {% endif %}
             {% if form.do_ocr.value %}
@@ -286,7 +286,7 @@ iframe-modal
             <input type="checkbox" id="id_{{ form.do_last_modified_check.name }}"
                    name="{{ form.do_last_modified_check.name }}"
                    value="{{ form.do_last_modified_check.name }}"
-            {% if view.edit %}
+            {% if form.do_last_modified_check.field.disabled %}
                 disabled
             {% endif %}
             {% if form.do_last_modified_check.value %}
@@ -302,7 +302,7 @@ iframe-modal
             <input type="checkbox" id="id_{{ form.do_last_modified_check_head_request.name }}"
                    name="{{ form.do_last_modified_check_head_request.name }}"
                    value="{{ form.do_last_modified_check_head_request.name }}"
-            {% if view.edit %}
+            {% if form.do_last_modified_check_head_request.field.disabled %}
                 disabled
             {% endif %}
             {% if form.do_last_modified_check_head_request.value %}
@@ -321,7 +321,7 @@ iframe-modal
                 <input type="checkbox" id="id_{{ form.do_link_check.name }}"
                        name="{{ form.do_link_check.name }}"
                        value="{{ form.do_link_check.name }}"
-                {% if view.edit %}
+                {% if form.do_link_check.field.disabled %}
                     disabled
                 {% endif %}
                 {% if form.do_link_check.value %}
@@ -336,7 +336,7 @@ iframe-modal
                 <input type="checkbox" id="id_{{ form.do_external_link_check.name }}"
                        name="{{ form.do_external_link_check.name }}"
                        value="{{ form.do_external_link_check.name }}"
-                {% if view.edit %}
+                {% if form.do_external_link_check.field.disabled %}
                     disabled
                 {% endif %}
                 {% if form.do_external_link_check.value %}
@@ -353,7 +353,7 @@ iframe-modal
                 <input type="checkbox" id="id_{{ form.do_collect_cookies.name }}"
                        name="{{ form.do_collect_cookies.name }}"
                        value="{{ form.do_collect_cookies.name }}"
-                {% if view.edit %}
+                {% if form.do_collect_cookies.field.disabled %}
                     disabled
                 {% endif %}
                 {% if form.do_collect_cookies.value %}
@@ -374,7 +374,7 @@ iframe-modal
             <div id="rules_list" class="dropup">
               <button class="btn btn-default dropdown-toggle" type="button"
                       data-toggle="dropdown" aria-haspopup="true" aria-expanded="true"
-                      {% if view.edit %} disabled {% endif %}>
+                      {% if form.regex_rules.field.disabled %} disabled {% endif %}>
                 Tilføj regler
                 <span class="caret"></span>
               </button>
@@ -458,7 +458,7 @@ iframe-modal
         function(e) {
             SelectFilter.init("id_domains",
               "domæner", 0, "{% static 'admin/' %}");
-            {% if view.edit %}
+            {% if form.domains.field.disabled %}
                 /*$("[id^=id_domains]").attr('disabled', true)
                 $("[id^=id_domains]").unbind()*/
                 $("#id_domains_container").css('opacity', '.35')

--- a/django-os2webscanner/os2webscanner/views/scanner_views.py
+++ b/django-os2webscanner/os2webscanner/views/scanner_views.py
@@ -87,6 +87,13 @@ class ScannerUpdate(ScannerBase, RestrictedUpdateView):
     """View for editing an existing scannerjob."""
     edit = True
 
+    editable_fields = (
+        'name',
+        'organisation',
+        'recipients',
+        'schedule',
+    )
+
     def get_form(self, form_class=None):
         """Get the form for the view.
 
@@ -95,6 +102,10 @@ class ScannerUpdate(ScannerBase, RestrictedUpdateView):
         superuser.
         """
         form = super().get_form(form_class)
+
+        for field_name, field in form.fields.items():
+            if field_name not in self.editable_fields:
+                form.fields[field_name].disabled = True
 
         scanner = self.get_scanner_object()
 


### PR DESCRIPTION
The proper way of preventing modifications to a field is to set it as
`disabled` in Django, so that Django disregards any modifications to
it. Merely setting it in the HTML will prevent the browser from
including it in the submission, but given that Django still expects
it, this effectively overwrites said value.

I've assumed this applies all fields on scanners other than the
following:

 - name
 - organisation
 - recipients
 - schedule