### PR TITLE
scanner manager: explicitly listen for child death

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -24,3 +24,4 @@ matplotlib==3.0.2
 xattr==0.9.6
 structlog==19.1.0
 django-structlog==1.2.3
+aio-pika==5.5.3

--- a/src/os2datascanner/engine/run.py
+++ b/src/os2datascanner/engine/run.py
@@ -32,21 +32,14 @@ from sys import stderr
 os.umask(0o007)
 os.environ["SCRAPY_SETTINGS_MODULE"] = "os2datascanner.engine.scanners.settings"
 
-# django_setup needs to be loaded before any imports from django app os2webscanner
-from .utils import run_django_setup
-
-run_django_setup()
-
 from os2datascanner.sites.admin.adminapp.models.statistic_model import Statistic
 from os2datascanner.sites.admin.adminapp.models.conversionqueueitem_model import ConversionQueueItem
 
-# Activate timezone from settings
 from django.core.exceptions import MultipleObjectsReturned
-from django.utils import timezone
-timezone.activate(timezone.get_default_timezone())
+
+from . import utils
 
 logger = structlog.get_logger()
-root_logger = logging.getLogger()
 
 
 class StartScan(object):
@@ -83,6 +76,7 @@ class StartScan(object):
         # Each scanner process should set up logging separately, writing to
         # both the log file and to the scanner manager's standard error stream
 
+        root_logger = logging.getLogger()
         root_logger.setLevel(logging.DEBUG)
         root_logger.addHandler(logging.FileHandler(self.logfile))
 
@@ -90,10 +84,6 @@ class StartScan(object):
         # happen after we've initialised the root logging handler
         self.crawler_process = \
             CrawlerProcess(self.settings, install_root_handler=False)
-
-        # A new instance of django setup needs to be loaded for the scan process,
-        # so the django db connection is not shared between processors.
-        run_django_setup()
 
     def make_scanner_crawler(self, spider_type):
         """Setup the scanner spider and crawler."""

--- a/src/os2datascanner/sites/admin/adminapp/management/commands/process_manager.py
+++ b/src/os2datascanner/sites/admin/adminapp/management/commands/process_manager.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # The contents of this file are subject to the Mozilla Public License
 # Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at
@@ -39,7 +38,6 @@ from django import db
 from django.conf import settings as django_settings
 
 from django.core.management.base import BaseCommand
-
 
 from ...models.conversionqueueitem_model import ConversionQueueItem
 from ...models.scans.scan_model import Scan
@@ -167,8 +165,6 @@ signal.signal(signal.SIGTERM | signal.SIGINT | signal.SIGQUIT, exit_handler)
 
 def main():
     """Main function."""
-    # Delete all inactive scan's queue items to start with
-    Scan.cleanup_finished_scans(timedelta(days=10000), log=True)
 
     prepare_processors()
 
@@ -182,9 +178,6 @@ def main():
         restart_terminated_processors()
 
         restart_stuck_processors()
-
-        # Cleanup finished scans from the last minute
-        Scan.cleanup_finished_scans(timedelta(minutes=1), log=True)
 
         Scan.pause_non_ocr_conversions_on_scans_with_too_many_ocr_items()
 

--- a/src/os2datascanner/sites/admin/adminapp/management/commands/scanner_manager.py
+++ b/src/os2datascanner/sites/admin/adminapp/management/commands/scanner_manager.py
@@ -1,40 +1,135 @@
-#!/usr/bin/env python
-
+import asyncio
 import json
-import time
 import logging
+import os
 
-import pika
+import aio_pika
 import structlog
 
+from django import db
+from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from os2datascanner.engine.run_webscan import StartWebScan
 from os2datascanner.engine.run_filescan import StartFileScan
 
+from ...models.scans.scan_model import Scan
+
 logger = structlog.get_logger()
 
 
-def callback(ch, method, properties, body):
+async def check_running_scans():
+    while True:
+        try:
+            with transaction.atomic():
+                running_scans = Scan.objects.filter(
+                    status=Scan.STARTED
+                ).select_for_update(nowait=True)
+
+                logger.debug("check_running_scans", scans=len(running_scans))
+
+                for scan in running_scans:
+                    if not scan.pid and not hasattr(scan, "exchangescan"):
+                        continue
+                    try:
+                        # Check if process is still running
+                        os.kill(scan.pid, 0)
+                        logger.debug(
+                            "scan_ok", scan=scan.pk, scan_pid=scan.pid
+                        )
+                    except OSError:
+                        logger.critical(
+                            "scan_disappeared",
+                            scan_id=scan.pk,
+                            scan_pid=scan.pid,
+                            exc_info=True,
+                        )
+
+                        scan.set_scan_status_failed(
+                            "FAILED: process {} disappeared".format(scan.pid)
+                        )
+
+        except Exception:
+            logger.warning("check_running_scans_failed", exc_info=True)
+
+        await asyncio.sleep(settings.CHECK_SCAN_INTERVAL)
+
+
+def handle_exit(pid, returncode, scan_id):
+    """A scan process died; update its status pending on the success value."""
+
+    if returncode == 0:
+        event = "scan_done"
+        level = logging.INFO
+
+        # should we call scan.set_status_done() here?
+
+    else:
+        event = "scan_failed"
+        level = logging.CRITICAL
+
+        scan = Scan.objects.get(pk=scan_id)
+        scan.set_status_failed("process exited with {}".format(returncode))
+
+    logger.log(level, event, scan_id=scan_id, scan_pid=pid, status=returncode)
+
+
+async def process_message(message):
+    """Process the given AMQP message, representing a scan.
+
+    This function should handle all exception internally.
+    """
     try:
-        scan_job_list = []
-        body = body.decode('utf-8')
+        body = message.body.decode("utf-8")
         body = json.loads(body)
-        logger.info('Receved scan', **body)
+    except Exception:
+        logger.exception("scan_invalid_message", message=message)
+        return
+
+    try:
+        logger.debug("scan_received", **body)
 
         # Collect scan object and map properties
         if body['type'] == 'WebScanner':
-            scan_job_list.append(StartWebScan(body))
+            scanjob = StartWebScan(body)
         else:
-            scan_job_list.append(StartFileScan(body))
-        scan_job_list[-1].start()
-        ch.basic_ack(delivery_tag=method.delivery_tag)
-    except Exception:
-        # reject the job; and delay so that we don't hog CPU
-        logger.exception('failed to start scan job')
-        ch.basic_reject(delivery_tag=method.delivery_tag)
+            scanjob = StartFileScan(body)
 
-        time.sleep(1)
+        scanjob.start()
+
+        asyncio.get_child_watcher().add_child_handler(
+            scanjob.pid, handle_exit, body["id"]
+        )
+
+        logger.info("scan_started", **body, child_id=scanjob.pid)
+
+        await message.ack()
+
+    except Exception as exc:
+        logger.critical("scan_start_failed", **body, exc_info=True)
+
+        scan = Scan.objects.get(pk=body["id"])
+        scan.set_scan_status_failed(str(exc))
+
+        await message.reject(requeue=False)
+
+
+async def listen(loop, host, queue_name):
+    logger.info("scanner_manager_ready")
+
+    # check for running scans at first available opportunity
+    loop.create_task(check_running_scans())
+
+    async with await aio_pika.connect_robust(host=host, loop=loop) as conn:
+        chann = await conn.channel()
+        queue = await chann.declare_queue(queue_name)
+
+        async with queue.iterator() as messages:
+            async for message in messages:
+                async with message.process(ignore_processed=True):
+                    await process_message(message)
+
 
 class Command(BaseCommand):
     help = __doc__
@@ -56,21 +151,13 @@ class Command(BaseCommand):
         )
 
     def handle(self, amqp_queue, amqp_host, **kwargs):
-        while True:
-            try:
-                connection = pika.BlockingConnection(
-                    pika.ConnectionParameters(amqp_host, heartbeat_interval=6000)
-                )
+        try:
+            with asyncio.FastChildWatcher() as watcher:
+                asyncio.set_child_watcher(watcher)
 
-                channel = connection.channel()
+                loop = asyncio.get_event_loop()
 
-                channel.queue_declare(queue=amqp_queue)
-                channel.basic_consume(callback, queue=amqp_queue)
-
-                channel.start_consuming()
-            except pika.exceptions.ConnectionClosed:
-                # the most frequent cause of sudden closures is VM
-                # suspensions, but just in case, log it, back off a bit, and
-                # resume
-                logger.exception('AMQP connection closed')
-                time.sleep(1)
+                loop.run_until_complete(listen(loop, amqp_host, amqp_queue))
+                loop.close()
+        except KeyboardInterrupt:
+            pass

--- a/src/os2datascanner/sites/admin/adminapp/management/commands/scanner_manager.py
+++ b/src/os2datascanner/sites/admin/adminapp/management/commands/scanner_manager.py
@@ -104,6 +104,11 @@ async def process_message(message):
         else:
             scanjob = StartFileScan(body)
 
+        # sharing opened connections between processes leads to issues
+        # with closed/open state getting out-of-sync -- so just close
+        # them all prior to forking the process
+        db.connections.close_all()
+
         scanjob.start()
 
         asyncio.get_child_watcher().add_child_handler(

--- a/src/os2datascanner/sites/admin/adminapp/models/scans/scan_model.py
+++ b/src/os2datascanner/sites/admin/adminapp/models/scans/scan_model.py
@@ -287,6 +287,8 @@ class Scan(models.Model):
 
     def cleanup_finished_scan(self):
         """Delete pending conversion queue items and remove the scan dir."""
+        self.delete_all_pending_conversionqueue_items()
+
         # remove all files associated with the scan
         if self.is_scan_dir_writable():
             self.delete_scan_dir()
@@ -314,7 +316,6 @@ class Scan(models.Model):
         )
 
         for scan in inactive_scans:
-            scan.delete_all_pending_conversionqueue_items()
             scan.cleanup_finished_scan()
 
     @classmethod
@@ -450,10 +451,7 @@ class Scan(models.Model):
         else:
             self.reason = reason
 
-        self.log_occurrence(
-            self.reason
-        )
-        # TODO: Remove all non-processed conversion queue items.
+        self.log_occurrence(self.reason)
         self.save()
 
     # Create method - copies fields from scanner

--- a/src/os2datascanner/sites/admin/adminapp/models/scans/scan_model.py
+++ b/src/os2datascanner/sites/admin/adminapp/models/scans/scan_model.py
@@ -25,7 +25,7 @@ import structlog
 
 from django.conf import settings
 from django.core.validators import validate_comma_separated_integer_list
-from django.db import models
+from django.db import models, transaction
 from django.db.models.aggregates import Count
 from django.utils import timezone
 
@@ -50,6 +50,10 @@ class Scan(models.Model):
         """
         super().__init__(*args, **kwargs)
         self._old_status = self.status
+
+    @property
+    def logger(self):
+        return logger.bind(scan_id=self.pk, scan_status=self.status)
 
     start_time = models.DateTimeField(blank=True, null=True,
                                       verbose_name='Starttidspunkt')
@@ -208,6 +212,8 @@ class Scan(models.Model):
 
     # Occurrence log - mainly for the scanner to notify when something FAILS.
     def log_occurrence(self, string):
+        self.logger.debug('scan_occurrence', occurrence=string)
+
         with open(self.occurrence_log_file, "a") as f:
             f.write("{0}\n".format(string))
 
@@ -279,51 +285,94 @@ class Scan(models.Model):
             self.cleanup_finished_scan()
             self._old_status = self.status
 
-    def cleanup_finished_scan(self, log=False):
+    def cleanup_finished_scan(self):
         """Delete pending conversion queue items and remove the scan dir."""
         # remove all files associated with the scan
         if self.is_scan_dir_writable():
-            self.delete_scan_dir(log)
+            self.delete_scan_dir()
 
     @classmethod
-    def cleanup_finished_scans(cls, scan_age, log=False):
+    def cleanup_finished_scans(cls, oldest_end_time: datetime.datetime):
         """Cleanup convqueue items from finished scans.
 
-        Only Scans that have ended since scan_age ago are considered.
-        scan_age should be a timedelta object.
+        Only Scans that have ended since oldest_end_time are considered.
         """
-        from django.utils import timezone
-        from django.db.models import Q
-        oldest_end_time = timezone.localtime(timezone.now()) - scan_age
+
         inactive_scans = cls.objects.filter(
-            Q(status__in=(Scan.DONE, Scan.FAILED)),
-            Q(end_time__gt=oldest_end_time) | Q(end_time__isnull=True)
+            models.Q(status__in=(Scan.DONE, Scan.FAILED)),
+            (
+                models.Q(end_time__gt=oldest_end_time) |
+                models.Q(end_time__isnull=True)
+            ),
+        )
+
+        logger.debug(
+            "cleanup_finished_scans",
+            since=oldest_end_time.isoformat(),
+            scans=len(inactive_scans),
+            type=cls.__name__,
         )
 
         for scan in inactive_scans:
-            scan.delete_all_pending_conversionqueue_items(log)
-            scan.cleanup_finished_scan(log=log)
+            scan.delete_all_pending_conversionqueue_items()
+            scan.cleanup_finished_scan()
 
-    def delete_all_pending_conversionqueue_items(self, log):
+    @classmethod
+    def check_running_scans(cls):
+        with transaction.atomic():
+            running_scans = cls.objects.filter(
+                status=cls.STARTED
+            ).select_for_update(nowait=True)
+
+            logger.debug(
+                "check_running_scans",
+                scans=len(running_scans),
+                type=cls.__name__,
+            )
+
+            for scan in running_scans:
+                if not scan.pid and not hasattr(scan, "exchangescan"):
+                    continue
+                try:
+                    # Check if process is still running
+                    os.kill(scan.pid, 0)
+                    logger.debug(
+                        "scan_ok", scan=scan.pk, scan_pid=scan.pid
+                    )
+                except OSError:
+                    logger.critical(
+                        "scan_disappeared",
+                        scan_id=scan.pk,
+                        scan_pid=scan.pid,
+                        exc_info=True,
+                    )
+
+                    scan.set_scan_status_failed(
+                        "FAILED: process {} disappeared".format(scan.pid)
+                    )
+
+    def delete_all_pending_conversionqueue_items(self):
         # Delete all pending conversionqueue items
         from ..conversionqueueitem_model import ConversionQueueItem
         pending_items = ConversionQueueItem.objects.filter(
             url__scan=self,
             status=ConversionQueueItem.NEW
         )
-        if log:
-            if pending_items.exists():
-                logger.info(
-                    "Deleting remaining conversion queue items from finished scan",
-                    count=pending_items.count(), scan_id=self.pk,
-                )
-        pending_items.delete()
 
-    def delete_scan_dir(self, log):
-        if log:
-            logger.debug('Delete scan directory', scan_id=self.pk, dir=self.scan_dir)
-            shutil.rmtree(self.scan_dir, True)
-            logger.debug('Directory deleted', scan_id=self.pk, dir=self.scan_dir)
+        if pending_items.exists():
+            self.logger.debug(
+                "remaining_scan_items",
+                count=pending_items.count(),
+            )
+            pending_items.delete()
+
+    def delete_scan_dir(self):
+        shutil.rmtree(self.scan_dir, True)
+        self.logger.debug(
+            "scan_dir_deleted",
+            scan_id=self.pk,
+            dir=self.scan_dir,
+        )
 
     @classmethod
     def pause_non_ocr_conversions_on_scans_with_too_many_ocr_items(cls):
@@ -350,20 +399,20 @@ class Scan(models.Model):
             num_ocr_items = items["total"]
             if (not scan.pause_non_ocr_conversions and
                         num_ocr_items > settings.PAUSE_NON_OCR_ITEMS_THRESHOLD):
-                logger.info(
+                self.logger.info(
                     "Pausing non-OCR conversions for scan "
                     "because it has too many OCR items",
-                    scan_id=scan.pk, num_ocr_items=num_ocr_items,
+                    num_ocr_items=num_ocr_items,
                     threshold=settings.PAUSE_NON_OCR_ITEMS_THRESHOLD,
                 )
                 scan.pause_non_ocr_conversions = True
                 scan.save()
             elif (scan.pause_non_ocr_conversions and
                           num_ocr_items < settings.RESUME_NON_OCR_ITEMS_THRESHOLD):
-                logger.info(
+                self.logger.info(
                     "Resuming non-OCR conversions for scan "
                     "as its OCR are under the threshold",
-                    scan_id=scan.pk, num_ocr_items=num_ocr_items,
+                    num_ocr_items=num_ocr_items,
                     threshold=settings.RESUME_NON_OCR_ITEMS_THRESHOLD,
                 )
                 scan.pause_non_ocr_conversions = False
@@ -383,9 +432,8 @@ class Scan(models.Model):
         self.start_time = datetime.datetime.now(tz=timezone.utc)
         self.status = Scan.STARTED
         self.reason = ""
-        pid = os.getpid()
-        logger.info('Starting scan job', pid=pid, scan_id=self.pk)
-        self.pid = pid
+        self.logger.debug('scan_started')
+        self.pid = os.getpid()
         self.save()
 
     def set_scan_status_done(self):

--- a/src/os2datascanner/sites/admin/adminapp/test/scanmodel_test.py
+++ b/src/os2datascanner/sites/admin/adminapp/test/scanmodel_test.py
@@ -33,5 +33,5 @@ class ScanModelTest(TestCase):
         os.makedirs(scan_object.scan_dir)
         self.assertTrue(os.path.exists(scan_object.scan_dir))
         time.sleep(2)
-        Scan.cleanup_finished_scans(timedelta(minutes=1), log=True)
+        Scan.cleanup_finished_scans(timedelta(minutes=1))
         self.assertFalse(os.path.exists(scan_object.scan_dir))

--- a/src/os2datascanner/sites/admin/settings.py
+++ b/src/os2datascanner/sites/admin/settings.py
@@ -64,6 +64,12 @@ ENABLE_FILESCAN = True
 # If exchangescan on the current installation is needed, enable it here
 ENABLE_EXCHANGESCAN = True
 
+# Check for dead scanner processes at this interval, in seconds
+CHECK_SCAN_INTERVAL = 300
+
+# Purge scanner queue items at this interval, in seconds
+CLEANUP_SCAN_INTERVAL = 300
+
 # Add settings here to make them accessible from templates
 SETTINGS_EXPORT = [
     'DEBUG',


### PR DESCRIPTION
This leaves just one operation relating to scans in the process manager:

```
        Scan.pause_non_ocr_conversions_on_scans_with_too_many_ocr_items()
```

I'm not quite comfortable moving that one to the `scanner_manager`, as it seems like we most certainly want to run that during processing.

---

We use `asyncio` for this despite the added complexity. First of all,
AMQP is inherently asynchronous and fits this model rather well, and
second of all this suits the concurrent nature of the tasks well. In
particular, `asyncio` makes listening for dying children rather easy.

Now that we get an explicit notification when a child dies, I've
relaxed the regular check: Instead of every ten seconds, we run it
every 5 minutes.

https://redmine.magenta-aps.dk/issues/28795