### PR TITLE
Updated psycopg2 to 2.8.2 - There was a dependency problem between ps…

### DIFF
--- a/doc/PYTHON_DEPENDENCIES
+++ b/doc/PYTHON_DEPENDENCIES
@@ -20,7 +20,7 @@ exchangelib==1.11.4
 ipython==6.4.0
 lxml==4.1.0
 pika==0.12.0
-psycopg2==2.7.3.2
+psycopg2==2.8.2
 psutil==5.4.6
 pyasn1==0.3.7
 pyasn1-modules==0.1.5


### PR DESCRIPTION
Python pakken psycopg2 brugte en SSL version der ikke var compatibel med SSL versionen Apaches ssl brugte i ubuntu 18.04 - så vidt jeg kunne læse mig frem til. Vi kunne i hvert fald ikke få apache til at køre sammen med mod_wsgi. Men ved at opdatere psycopg2 til 2.8.2 virkede det, og i deres changelog kan det også læses at de har opgraderet deres SSL.

Det er testet at web-serveren kan startes både fra ubuntu 18.04 og 16.04 nu, men jeg har ikke kunne teste om dette vil give problemer når man kører nogle scanninger. Det ser dog ikke ud til der er fjernet noget vigtigt i den nyere release af psycopg2 