### PR TITLE
Feature/29426 broken links bliver ikke vist

### DIFF
--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -348,9 +348,7 @@ Rapport
         <div>
             <p> Here i show broken urls from sitemap.xml </p>
             {% for burl in no_referrer_urls %}
-                {% for bref in burl.referrers.all %}
-                    <p> {{ bref }} </p>
-                {% endfor %}
+                    <p> {{ burl }} </p>
             {% endfor %}
         </div>
     </div>

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -344,6 +344,13 @@ Rapport
 
                 </tr>
             {% endfor %}
+            {% if no_referrer_urls %}
+                {% for burl in no_referrer_urls %}
+                    {% for bref in burl.referrers %}
+                        <p> {{ bref }} </p>
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
     </div>
     {% endif %}
       

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -348,7 +348,7 @@ Rapport
         <div>
             <p> Here i show broken urls from sitemap.xml </p>
             {% for burl in no_referrer_urls %}
-                {% for bref in burl.referrers %}
+                {% for bref in burl.referrers.all %}
                     <p> {{ bref }} </p>
                 {% endfor %}
             {% endfor %}

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -639,8 +639,8 @@ Rapport
             linkMarkup += "<span class='label label-danger'>"+ error[i] +"</span></a>";
         }
 
-        $("#list-links").html('Finder links...');
-        prevTarg = null;
+        //$("#list-links").html('Finder links...');
+        //prevTarg = null;
     }
 
     document.onready = function() {

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -345,14 +345,15 @@ Rapport
                 </tr>
             {% endfor %}
         </table>
-    </div>
-            {% if no_referrer_urls %}
-                {% for burl in no_referrer_urls %}
-                    {% for bref in burl.referrers %}
-                        <p> {{ bref }} </p>
-                    {% endfor %}
+        <div>
+            <p> Here i show broken urls from sitemap.xml </p>
+            {% for burl in no_referrer_urls %}
+                {% for bref in burl.referrers %}
+                    <p> {{ bref }} </p>
                 {% endfor %}
-            {% endif %}
+            {% endfor %}
+        </div>
+    </div>
     {% endif %}
       
     {% if failed_conversions or scan.status == "FAILED" %}

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -344,6 +344,8 @@ Rapport
 
                 </tr>
             {% endfor %}
+        </table>
+    </div>
             {% if no_referrer_urls %}
                 {% for burl in no_referrer_urls %}
                     {% for bref in burl.referrers %}
@@ -351,7 +353,6 @@ Rapport
                     {% endfor %}
                 {% endfor %}
             {% endif %}
-    </div>
     {% endif %}
       
     {% if failed_conversions or scan.status == "FAILED" %}

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -366,14 +366,12 @@ Rapport
                                 "{{ url }}",
                             {% endfor %}
                             );
-                            status_messages.push(get_messages);
-                            all_broken.push(all_broken_urls);
                         </script>
                         <button type="button"
                                 class="btn btn-default"
                                 data-toggle="modal"
                                 data-target="#view-deadlinks-modal"
-                                onclick="showReferrerUrl('other','other',all_broken[{{ forloop.counter0 }}],status_messages[{{ forloop.counter0 }}])">
+                                onclick="showReferrerUrl('other','other',all_broken_urls,get_messages)">
                         <span class="glyphicon glyphicon-eye-open"></span>
                         Inspicér
                         </button>
@@ -630,8 +628,8 @@ Rapport
 
     function showReferrerUrl(id, url, broken_link, error) {
         console.log(id, url, broken_link, error)
-        var url_mask = "{% url 'referrer_content' pk=12345 %}".replace(/12345/, id.toString());
-        document.getElementById("iframe").src = url_mask;
+        //var url_mask = "{% url 'referrer_content' pk=12345 %}".replace(/12345/, id.toString());
+        //document.getElementById("iframe").src = url_mask;
 
         $("#create-summary-modal-title span").html('<a href="' + url + '">' + url + '</a>');
 

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -344,12 +344,51 @@ Rapport
 
                 </tr>
             {% endfor %}
+            {% if no_referrer_urls %} 
+                <tr class="danger">
+                <td class="broken-url-referrers">
+                    <p target="_NEW">Andre links - Højest sandsynligt fra sitemap</p>
+                </td>
+
+                <td class="broken-url-count">
+                    <span class="badge">{{no_referrer_urls.count}}</span>
+                </td>
+
+                <td class="broken-url-show">
+                    <p>
+                        <script>
+                            var get_messages = Array(
+                            {% for broken in no_referrer_urls %}
+                                "{{ broken.status_message }}",
+                            {% endfor %});
+                            var all_broken_urls = Array(
+                            {% for url in no_referrer_urls.all %}
+                                "{{ url }}",
+                            {% endfor %}
+                            );
+                            status_messages.push(get_messages);
+                            all_broken.push(all_broken_urls);
+                        </script>
+                        <button type="button"
+                                class="btn btn-default"
+                                data-toggle="modal"
+                                data-target="#view-deadlinks-modal"
+                                onclick="showReferrerUrl('other','other',all_broken[{{ forloop.counter0 }}],status_messages[{{ forloop.counter0 }}])">
+                        <span class="glyphicon glyphicon-eye-open"></span>
+                        Inspicér
+                        </button>
+                    </p>
+                </td>
+
+                </tr>
+                {% for burl in no_referrer_urls %}
+                    
+                        <p> {{ burl }} </p>
+                {% endfor %}
+            {% endif %}
         </table>
         <div>
             <p> Here i show broken urls from sitemap.xml </p>
-            {% for burl in no_referrer_urls %}
-                    <p> {{ burl }} </p>
-            {% endfor %}
         </div>
     </div>
     {% endif %}

--- a/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
+++ b/django-os2webscanner/os2webscanner/templates/os2webscanner/report.html
@@ -371,7 +371,7 @@ Rapport
                                 class="btn btn-default"
                                 data-toggle="modal"
                                 data-target="#view-deadlinks-modal"
-                                onclick="showReferrerUrl('other','other',all_broken_urls,get_messages)">
+                                onclick="showReferrerUrl('','',all_broken_urls,get_messages)">
                         <span class="glyphicon glyphicon-eye-open"></span>
                         Inspicér
                         </button>
@@ -379,15 +379,8 @@ Rapport
                 </td>
 
                 </tr>
-                {% for burl in no_referrer_urls %}
-                    
-                        <p> {{ burl }} </p>
-                {% endfor %}
             {% endif %}
         </table>
-        <div>
-            <p> Here i show broken urls from sitemap.xml </p>
-        </div>
     </div>
     {% endif %}
       
@@ -628,8 +621,13 @@ Rapport
 
     function showReferrerUrl(id, url, broken_link, error) {
         console.log(id, url, broken_link, error)
-        //var url_mask = "{% url 'referrer_content' pk=12345 %}".replace(/12345/, id.toString());
-        //document.getElementById("iframe").src = url_mask;
+        $("#list-links").html('Finder links...');
+        if(url == ''){
+            document.getElementById("iframe").srcdoc = "";
+        } else {
+            var url_mask = "{% url 'referrer_content' pk=12345 %}".replace(/12345/, id.toString());
+            document.getElementById("iframe").src = url_mask;
+        }
 
         $("#create-summary-modal-title span").html('<a href="' + url + '">' + url + '</a>');
 
@@ -639,8 +637,7 @@ Rapport
             linkMarkup += "<span class='label label-danger'>"+ error[i] +"</span></a>";
         }
 
-        //$("#list-links").html('Finder links...');
-        //prevTarg = null;
+        prevTarg = null;
     }
 
     document.onready = function() {

--- a/django-os2webscanner/os2webscanner/views/report_views.py
+++ b/django-os2webscanner/os2webscanner/views/report_views.py
@@ -127,6 +127,7 @@ class ReportDetails(UpdateView, LoginRequiredMixin):
         context['broken_urls'] = broken_urls[:100]
         context['no_of_broken_links'] = broken_urls.count()
         context['referrer_urls'] = referrer_urls
+        context['no_referrer_urls'] = no_referrer_urls
         context['matches'] = all_matches[:100]
         context['all_matches'] = all_matches
         context['no_of_matches'] = all_matches.count() + broken_urls.count()

--- a/django-os2webscanner/os2webscanner/views/report_views.py
+++ b/django-os2webscanner/os2webscanner/views/report_views.py
@@ -119,6 +119,8 @@ class ReportDetails(UpdateView, LoginRequiredMixin):
             scan=this_scan
         ).exclude(status_code__isnull=True).order_by('url')
 
+        no_referrer_urls = broken_urls
+
         referrer_urls = ReferrerUrl.objects.filter(scan=this_scan)
 
         context['full_report'] = self.full

--- a/django-os2webscanner/os2webscanner/views/report_views.py
+++ b/django-os2webscanner/os2webscanner/views/report_views.py
@@ -119,7 +119,7 @@ class ReportDetails(UpdateView, LoginRequiredMixin):
             scan=this_scan
         ).exclude(status_code__isnull=True).order_by('url')
 
-        no_referrer_urls = broken_urls.filter(referrer_isnull=True)
+        no_referrer_urls = broken_urls.filter(referrers__isnull=True)
 
         referrer_urls = ReferrerUrl.objects.filter(scan=this_scan)
 

--- a/django-os2webscanner/os2webscanner/views/report_views.py
+++ b/django-os2webscanner/os2webscanner/views/report_views.py
@@ -119,7 +119,7 @@ class ReportDetails(UpdateView, LoginRequiredMixin):
             scan=this_scan
         ).exclude(status_code__isnull=True).order_by('url')
 
-        no_referrer_urls = broken_urls
+        no_referrer_urls = broken_urls.filter(referrer_isnull=True)
 
         referrer_urls = ReferrerUrl.objects.filter(scan=this_scan)
 


### PR DESCRIPTION
Links fra sitemappet, der ikke pegede på noget korrekt blev ikke vist i brugergrænsefladen. 
Dette skyldtes at man fandt broken links ud fra referrer, og broken links fra sitemap ikke havde nogen referrer. 

Jeg har derfor tilføjet no_referrer_urls, til disse links, og tilsvarende logik i frontend, til at kunne vise links hvor refferer er None.