### PR TITLE
#30259: tweaks to Last-Modified date handling

### DIFF
--- a/scrapy-webscanner/scanners/middlewares/webscan_middleware.py
+++ b/scrapy-webscanner/scanners/middlewares/webscan_middleware.py
@@ -121,25 +121,18 @@ class WebScanLastModifiedCheckMiddleware(LastModifiedCheckMiddleware):
                             "Date format error on last modied: {0}".format(lm)
                         )
 
-        # lastmod comes from a sitemap.xml file
         sitemap_lastmod_date = request.meta.get("lastmod", None)
-        if sitemap_lastmod_date is None:
+        # We consider that the Last-Modified date we get out of a sitemap is
+        # more trustworthy than what we get out of the headers, so -- if we
+        # have one -- use it unconditionally
+        if sitemap_lastmod_date is not None:
+            last_modified = sitemap_lastmod_date
+            logging.debug(
+                    "Using sitemap's last-modified date: %s" % last_modified)
+        elif last_modified_header_date is not None:
             last_modified = last_modified_header_date
-            logging.debug("Using header's last-modified date: %s"
-                          % last_modified)
-        else:
-            if last_modified_header_date is None:
-                # No Last-Modified header, use the lastmod from the sitemap
-                last_modified = sitemap_lastmod_date
-                logging.debug("Using lastmod from sitemap %s" % last_modified)
-            else:
-                # Take the most recent of the two
-                logging.debug("Taking most recent of (header) %sand (sitemap) %s"
-                              % (last_modified_header_date,
-                                 sitemap_lastmod_date))
-                last_modified = max(last_modified_header_date,
-                                    sitemap_lastmod_date)
-                logging.debug("Last modified %s" % last_modified)
+            logging.debug(
+                    "Using header's last-modified date: %s" % last_modified)
 
         if last_modified is not None:
             # Check against the database

--- a/scrapy-webscanner/scanners/middlewares/webscan_middleware.py
+++ b/scrapy-webscanner/scanners/middlewares/webscan_middleware.py
@@ -100,27 +100,6 @@ class WebScanLastModifiedCheckMiddleware(LastModifiedCheckMiddleware):
         else:
             last_modified_header_date = None
 
-        if last_modified_header_date is None and request.method == 'GET':
-            content_type_header = response.headers.get(
-                "Content-Type", None
-            ).decode('utf-8')
-            if content_type_header.startswith("text/html"):
-                try:
-                    body_html = html.fromstring(response.body)
-                except Exception:
-                    logging.info('Error occured while trying to extract string from response body.')
-
-                meta_dict = {list(el.values())[0]: list(el.values())[1]
-                             for el in body_html.findall('head/meta')}
-                if 'last-modified' in meta_dict:
-                    lm = meta_dict['last-modified']
-                    try:
-                        last_modified_header_date = arrow.get(lm).datetime
-                    except Exception:
-                        logging.error(
-                            "Date format error on last modied: {0}".format(lm)
-                        )
-
         sitemap_lastmod_date = request.meta.get("lastmod", None)
         # We consider that the Last-Modified date we get out of a sitemap is
         # more trustworthy than what we get out of the headers, so -- if we


### PR DESCRIPTION
This (untested, because I have no idea what state my database is in at this point) branch _should_ make webscans prefer sitemap timestamps to HTTP header ones. It also removes a big adjacent block of weird code.

I'll open a separate pull request for merging these changes into `development` as well -- since we plan to keep Scrapy around as the webscan engine, there's no reason not to include it in both release series.